### PR TITLE
adds check for remove from playlist flag

### DIFF
--- a/spotify_ripper/post_actions.py
+++ b/spotify_ripper/post_actions.py
@@ -283,9 +283,10 @@ class PostActions(object):
                       "Did you use '-r' without a playlist link?" + Fore.RESET)
 
     def remove_tracks_from_playlist(self):
-        ripper = self.ripper
-        remove_all_from_playlist(ripper.session.user.canonical_name, ripper.playlist_uri)
-        print("Playlist Emptied!")
+        if self.args.remove_from_playlist:
+            ripper = self.ripper
+            remove_all_from_playlist(ripper.session.user.canonical_name, ripper.playlist_uri)
+            print("Playlist Emptied!")
 
     def remove_offline_cache(self):
         ripper = self.ripper

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -230,10 +230,12 @@ class Ripper(threading.Thread):
 
             # TODO: remove dependency on current_album, ...
             for idx, track in enumerate(tracks):
-
                 # ignore local tracks
                 if track.is_local:
                     continue
+
+                if "track_load_hook" in dir(self):
+                    self.track_load_hook(idx, track)
 
                 audio_file = self.format_track_path(idx, track)
                 all_tracks.append((track, audio_file))

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -73,11 +73,11 @@ class Ripper(threading.Thread):
     skip = threading.Event()
     play_token_resume = threading.Event()
 
-    def __init__(self, args):
+    def __init__(self, args, progress_obj=Progress):
         threading.Thread.__init__(self)
 
         # initialize progress meter
-        self.progress = Progress(args, self)
+        self.progress = progress_obj(args, self)
 
         self.args = args
 

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -614,8 +614,9 @@ class Ripper(threading.Thread):
         if track.link.uri in self.track_path_cache:
             return self.track_path_cache[track.link.uri]
 
+        tags = get_current_track_details(self, args.format.strip(), idx, track)
         audio_file = \
-            format_track_string(self, args.format.strip(), idx, track)
+            format_track_string(args.format.strip(), tags)
 
         # in case the file name is too long
         def truncate(_str, max_size):

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -164,9 +164,9 @@ def get_playlist_track(track, playlist):
 def change_file_extension(file_name, ext):
     return os.path.splitext(file_name)[0] + "." + ext
 
-
-def format_track_string(ripper, format_string, idx, track):
+def get_current_track_details(ripper, format_string, idx, track):
     args = get_args()
+
     current_album = ripper.current_album
     current_playlist = ripper.current_playlist
 
@@ -237,7 +237,7 @@ def format_track_string(ripper, format_string, idx, track):
     # load copyright only if needed
     copyright = label = ""
     if (format_string.find("{copyright}") >= 0 or
-            format_string.find("{label}") >= 0):
+                format_string.find("{label}") >= 0):
         album_browser = track.album.browse()
         album_browser.load(args.timeout)
         if len(album_browser.copyrights) > 0:
@@ -247,11 +247,11 @@ def format_track_string(ripper, format_string, idx, track):
     # load playlist create time or creator only if needed
     create_time = creator = ""
     if format_string.find("{create_time}") >= 0 or \
-            format_string.find("{creator}") >= 0:
+                    format_string.find("{creator}") >= 0:
         pl_track = get_playlist_track(track, current_playlist)
         if pl_track is not None:
             create_time = datetime.fromtimestamp(
-                    pl_track.create_time).strftime('%Y-%m-%d %H:%M:%S')
+                pl_track.create_time).strftime('%Y-%m-%d %H:%M:%S')
             creator = pl_track.creator.display_name
 
     tags = {
@@ -297,6 +297,10 @@ def format_track_string(ripper, format_string, idx, track):
         "track_uri": track_uri,
         "uri": track_uri
     }
+    return tags
+
+def format_track_string(format_string, tags):
+    args = get_args()
     fill_tags = {"idx", "index", "track_num", "track_idx",
                  "track_index", "disc_num", "disc_idx", "disc_index",
                  "smart_track_num", "smart_track_idx", "smart_track_index"}


### PR DESCRIPTION
If the remove from playlist setting arg is set to false the software still tries to remove from playlist.  It looks like when the previous method was deprecated a flag check was forgotten, so the software always tries to remove from playlist.