### PR TITLE
use spotify client parameters from config.ini

### DIFF
--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -119,6 +119,18 @@ def main(prog_args=sys.argv[1:]):
     }
     defaults = load_config(defaults)
 
+    spotipy_envs = [
+        "SPOTIPY_CLIENT_ID",
+        "SPOTIPY_CLIENT_SECRET",
+        "SPOTIPY_REDIRECT_URI"
+    ]
+
+    for spotipy_env in spotipy_envs:
+        if spotipy_env not in os.environ:
+            value = defaults.get(spotipy_env.lower())
+            if value:
+                os.environ[spotipy_env] = value
+
     parser = argparse.ArgumentParser(
         prog='spotify-ripper',
         description='Rips Spotify URIs to MP3s with ID3 tags and album covers',


### PR DESCRIPTION
It is awkward to use environment variables in a standlone python program. This PR allows to put the client credentials into `config.ini`.

This PR is added as reference for users who wish to get certain fixes without the need for @SolidHal to accept these PRs any time soon. This PR is collected in branch [wolfmanx/spotify-ripper/pr-collect](https://github.com/wolfmanx/spotify-ripper/tree/pr-collect), which can be used to get a version with all fixes and enhancements.
