### PR TITLE
eliminate main.py installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ setup(
     name='spotify-ripper',
     version='2.10.5',
     packages=find_packages(exclude=["tests"]),
-    scripts=['spotify_ripper/main.py'],
+    #scripts=['spotify_ripper/main.py'],
     include_package_data=True,
     zip_safe=False,
 
     # Executable
     entry_points={
         'console_scripts': [
-            'spotify-ripper = main:main',
+            'spotify-ripper = spotify_ripper.main:main',
         ],
     },
 


### PR DESCRIPTION
Installing `main.py` with the console script is ugly. This PR eliminates installation of `main.py`.

This PR is added as reference for users who wish to get certain fixes without the need for @SolidHal to accept these PRs any time soon. This PR is collected in branch [wolfmanx/spotify-ripper/pr-collect](https://github.com/wolfmanx/spotify-ripper/tree/pr-collect), which can be used to get a version with all fixes and enhancements.
