### PR TITLE
sync reported track index to track number

### DIFF
--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -272,6 +272,7 @@ class Ripper(threading.Thread):
                             Fore.RED + 'Track is not available, '
                                        'skipping...' + Fore.RESET)
                         self.post.log_failure(track)
+                        self.progress.track_idx += 1
                         continue
 
                     self.audio_file = self.format_track_path(idx, track)
@@ -285,6 +286,7 @@ class Ripper(threading.Thread):
                                 track.link.uri + Fore.RESET)
                             print(Fore.CYAN + self.audio_file + Fore.RESET)
                             self.post.queue_remove_from_playlist(idx)
+                            self.progress.track_idx += 1
                             continue
 
                     self.session.player.load(track)


### PR DESCRIPTION
This PR synchronizes the displayed track index with the track number being processed (the index is incremented for skipped tracks also). This is just a cosmetic change.

This PR is added as reference for users who wish to get certain fixes without the need for @SolidHal to accept these PRs any time soon. This PR is collected in branch [wolfmanx/spotify-ripper/pr-collect](https://github.com/wolfmanx/spotify-ripper/tree/pr-collect), which can be used to get a version with all fixes and enhancements.
